### PR TITLE
Fix start command for Python deployment to use app entrypoint

### DIFF
--- a/python/Dockerfile.server
+++ b/python/Dockerfile.server
@@ -90,4 +90,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD sh -c "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:${ARCHON_SERVER_PORT}/health')\""
 
 # Run the Server service
-CMD sh -c "python -m uvicorn src.server.main:socket_app --host 0.0.0.0 --port ${ARCHON_SERVER_PORT} --workers 1"
+CMD sh -c "python -m uvicorn src.server.main:app --host 0.0.0.0 --port ${ARCHON_SERVER_PORT} --workers 1"


### PR DESCRIPTION
## Summary
- Fixes the missing/incorrect start command in the Python server deployment by pointing uvicorn to the correct app entrypoint (src.server.main:app).
- Replaces the previous socket_app entrypoint which is not used in this codebase.

## Changes
### Dockerfile
- **python/Dockerfile.server**: Update CMD to run
  ```bash
  python -m uvicorn src.server.main:app --host 0.0.0.0 --port ${ARCHON_SERVER_PORT} --workers 1
  ```
  instead of `src.server.main:socket_app`.

### Rationale
- The application exposes a FastAPI instance named `app`. Using `socket_app` was incorrect and caused startup issues.

## Test plan
- [x] Build the image and run the container; ensure uvicorn starts and binds to the configured ARCHON_SERVER_PORT.
- [x] Verify healthcheck endpoint reports healthy.
- [x] Perform a basic smoke test of the API (where available) to confirm the server responds correctly.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/903ee516-a9bf-4775-9e8a-b1c166eebf1a