### PR TITLE
Fix ModuleNotFoundError for src module in server

### DIFF
--- a/python/Procfile
+++ b/python/Procfile
@@ -1,0 +1,1 @@
+web: python -m uvicorn src.server.main:app --host 0.0.0.0 --port $PORT

--- a/railway.json
+++ b/railway.json
@@ -2,7 +2,8 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "python/Dockerfile.server"
+    "dockerfilePath": "Dockerfile.server",
+    "buildContext": "python"
   },
   "deploy": {
     "numReplicas": 1,


### PR DESCRIPTION
## Summary
- Fixes ModuleNotFoundError for the 'src' module by ensuring the server starts with the correct module path and build context.

## Changes
- Added python/Procfile to run the app with uvicorn from the src path:
  - web: python -m uvicorn src.server.main:app --host 0.0.0.0 --port $PORT
- Updated Railway configuration (railway.json):
  - dockerfilePath changed from python/Dockerfile.server to Dockerfile.server
  - buildContext added: python

## Rationale
- The error occurred because the Docker build context and module path prevented Python from locating the src package. Using the correct build context and an explicit Procfile command ensures uvicorn can import src.server.main and start the app reliably both locally and on Railway.

## Testing
- Local:
  - Use the Procfile to start the app and verify the API is reachable at the configured port.
- Deployment:
  - Build on Railway with the updated dockerfilePath and buildContext and confirm the application starts without ModuleNotFoundError and serves the API endpoints.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/75a5177f-c8b8-4804-a8e0-1e2f54043e8f