### PR TITLE
Add make build target to build Docker images without cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 # Docker compose command - prefer newer 'docker compose' plugin over standalone 'docker-compose'
 COMPOSE ?= $(shell docker compose version >/dev/null 2>&1 && echo "docker compose" || echo "docker-compose")
 
-.PHONY: help dev dev-docker stop restart restart-rebuild test test-fe test-be test-be-unit test-be-coverage test-be-build test-be-interactive test-integration-sqlite-qdrant lint lint-fe lint-be clean install check start-mcp-http stop-mcp-http
+.PHONY: help dev dev-docker stop restart restart-rebuild test test-fe test-be test-be-unit test-be-coverage test-be-build test-be-interactive test-integration-sqlite-qdrant lint lint-fe lint-be clean install check start-mcp-http stop-mcp-http build
 
 MCP_HTTP_HOST ?= 127.0.0.1
 MCP_HTTP_PORT ?= 8765
@@ -23,6 +23,9 @@ help:
 	@echo "  make restart           - Quick restart (no rebuild)"
 	@echo "  make restart-rebuild   - Restart with full rebuild"
 	@echo "  make clean             - Remove containers and volumes"
+	@echo ""
+	@echo "Build:"
+	@echo "  make build             - Build all Docker images (no cache)"
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test              - Run all tests"
@@ -201,6 +204,12 @@ stop-mcp-http:
 	else \
 		echo "FastMCP HTTP server is not running"; \
 	fi
+
+# Build all Docker images without cache
+build:
+	@echo "Building all Docker images (no cache)..."
+	@$(COMPOSE) build --no-cache
+	@echo "✓ All images built successfully"
 
 # Clean everything (with confirmation)
 clean:


### PR DESCRIPTION
## Summary
- Adds a new Makefile target to build all Docker images without using the cache.

## Changes
### Makefile
- Exposed a new phony target: `build` in the PHONY list.
- Implemented the `build` rule to build all Docker images with `--no-cache` using the existing `$(COMPOSE)` command.
- Updated the help output to document the new Build option.

### Build behavior
- This change does not affect runtime behavior; it provides a convenient way to perform a fresh image build for development.

## How to test
- [x] Run `make build` and verify that all images are rebuilt without cache, with messages like:
  - "Building all Docker images (no cache)..."
  - "✓ All images built successfully"
- [x] Run `make help` and confirm the new Build section is visible:
  - Build:
  -   make build - Build all Docker images (no cache)



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4683cd7f-5d7d-41b5-a084-589ae9b876e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new build option for fresh, cache-free builds
  * Introduced configurable settings for HTTP server management (path, process file, and logging)

* **Documentation**
  * Enhanced help documentation with Build section and new configuration options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->